### PR TITLE
Fix order of auth tokens arguments

### DIFF
--- a/src/glap/cli.py
+++ b/src/glap/cli.py
@@ -102,7 +102,7 @@ def gitlab_instance(remote):
     private_token = remote.get(PRIVATE_TOKEN_KEY)
     oauth_token = remote.get(OAUTH_TOKEN_KEY)
     job_token = remote.get(JOB_TOKEN_KEY)
-    return gitlab.Gitlab(url, private_token, job_token, oauth_token)
+    return gitlab.Gitlab(url, private_token, oauth_token, job_token)
 
 
 def download_and_unzip_artifacts(project, output, branch, job, temp, verbose, silent):


### PR DESCRIPTION
The order of the auth tokens arguments in the [`gitlab.Gitlab` class constructor](https://github.com/python-gitlab/python-gitlab/blob/643454c5c5bbfb66d5890232a4f07fb04a753486/gitlab/__init__.py#L74-L76) is:

1. `private_token`
2. `oauth_token`
3. `job_token`