### PR TITLE
Get project lazily

### DIFF
--- a/src/glap/cli.py
+++ b/src/glap/cli.py
@@ -91,7 +91,7 @@ def connect_and_download(remote, namespace, repository, ref, job, output, temp, 
     if check_remote(remote):
         try:
             gl = gitlab_instance(remote)
-            project = gl.projects.get(f"{namespace}/{repository}")
+            project = gl.projects.get(f"{namespace}/{repository}", lazy=True)
             if verbose:
                 print(
                     f"Job {job}@{ref} from {remote['url']}{namespace}/{repository}")


### PR DESCRIPTION
`CI_JOB_TOKEN` can only access a few API endpoints including artifacts download, but getting project information is not possible. Fortunately, getting project information is not needed for downloading artifacts.

This PR makes artifacts download possible also with the limited permissions of `CI_JOB_TOKEN`.

@Mountlex 